### PR TITLE
feat: Implement AWS infrastructure for API deployment

### DIFF
--- a/.github/workflows/docker-image-push.yml
+++ b/.github/workflows/docker-image-push.yml
@@ -1,48 +1,164 @@
-name: Docker Image Build & Push
+name: Backend API CI/CD - Build and Deploy to ECS
 
 on:
-  workflow_call:
+  push:
+    branches:
+      - main # Triggers on pushes to the main branch
+  workflow_dispatch: # Allows manual triggering
     inputs:
       tag:
-        description: 'Tag for image'
+        description: 'Manual tag for image (optional, defaults to Git SHA)'
         type: string
-        required: true
-  workflow_dispatch:
-    inputs:
-      tag:
-        description: 'Tag for image'
-        type: string
-        required: true
+        required: false
+
+env:
+  # These should be set as GitHub Secrets in your repository settings
+  # Or, if not sensitive and environment-specific, could be vars
+  AWS_REGION: ${{ secrets.AWS_REGION || 'us-east-1' }}
+  ECR_REPOSITORY_NAME: ${{ secrets.ECR_REPOSITORY_NAME }}
+  ECS_CLUSTER_NAME: ${{ secrets.ECS_CLUSTER_NAME }}
+  ECS_SERVICE_NAME: ${{ secrets.ECS_SERVICE_NAME }}
+  ECS_TASK_DEFINITION_FAMILY: ${{ secrets.ECS_TASK_DEFINITION_FAMILY }} # e.g., my-app-task-def (without revision)
+  ECS_CONTAINER_NAME: ${{ secrets.ECS_CONTAINER_NAME }} # The name of the container in your task definition
 
 jobs:
-  build:
+  build-and-deploy:
     runs-on: ubuntu-latest
-
     permissions:
       contents: read
-      packages: write
+      # id-token: write # Required for OIDC if using configure-aws-credentials with role-to-assume
+      packages: write # If you were pushing to ghcr.io, not needed for ECR
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - uses: actions/setup-java@v4
+      - name: Setup Java
+        uses: actions/setup-java@v4
         with:
-          distribution: corretto
-          java-version: 17
+          distribution: 'corretto' # Using Corretto as per Dockerfile
+          java-version: '21' # Match JDK in Dockerfile
 
-      - name: Log in to the Container registry
-        uses: docker/login-action@v3
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
 
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: ./backend/api/Dockerfile
-          push: true
-          no-cache: true
-          tags: ghcr.io/${{ github.actor }}/self-hr-api:${{ inputs.tag }}
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Set image tags
+        id: image-tags
+        run: |
+          GIT_SHA=$(git rev-parse --short HEAD)
+          MANUAL_TAG=${{ inputs.tag }}
+          IMAGE_TAG_SHA="${GIT_SHA}"
+          IMAGE_TAG_LATEST="latest"
+          if [ -n "$MANUAL_TAG" ]; then
+            echo "ECR_IMAGE_TAG_MANUAL=${{ env.ECR_REPOSITORY_NAME }}:$MANUAL_TAG" >> $GITHUB_ENV
+          fi
+          echo "ECR_IMAGE_URI_SHA=${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY_NAME }}:$IMAGE_TAG_SHA" >> $GITHUB_ENV
+          echo "ECR_IMAGE_URI_LATEST=${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY_NAME }}:$IMAGE_TAG_LATEST" >> $GITHUB_ENV
+          echo "Image URI with SHA: ${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY_NAME }}:$IMAGE_TAG_SHA"
+          echo "Image URI with latest: ${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY_NAME }}:$IMAGE_TAG_LATEST"
+
+      - name: Build, tag, and push image to Amazon ECR
+        id: build-image
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+        run: |
+          docker build -t $ECR_IMAGE_URI_SHA -t $ECR_IMAGE_URI_LATEST -f backend/api/Dockerfile .
+          docker push $ECR_IMAGE_URI_SHA
+          docker push $ECR_IMAGE_URI_LATEST
+          if [ -n "${{ env.ECR_IMAGE_TAG_MANUAL }}" ]; then
+            docker tag $ECR_IMAGE_URI_SHA ${{ env.ECR_IMAGE_TAG_MANUAL }}
+            docker push ${{ env.ECR_IMAGE_TAG_MANUAL }}
+            echo "Also pushed manual tag: ${{ env.ECR_IMAGE_TAG_MANUAL }}"
+          fi
+        # Note: Consider using docker/build-push-action@v5 if preferred,
+        # but ensure it can output the image URI with the new SHA tag for the ECS task def update.
+        # For this example, direct docker commands are used for clarity in tagging and pushing.
+
+      - name: Download current ECS task definition
+        id: download-task-def
+        run: |
+          aws ecs describe-task-definition --task-definition ${{ env.ECS_TASK_DEFINITION_FAMILY }} --region ${{ env.AWS_REGION }} --query taskDefinition > task-definition.json
+          echo "TASK_DEFINITION_FILE=task-definition.json" >> $GITHUB_ENV
+          echo "Current task definition downloaded to task-definition.json"
+          # Store current task def ARN to ensure we update the correct one if multiple services use the same family prefix
+          CURRENT_TASK_DEF_ARN=$(jq -r .taskDefinitionArn task-definition.json)
+          echo "CURRENT_TASK_DEF_ARN=$CURRENT_TASK_DEF_ARN" >> $GITHUB_ENV
+
+
+      - name: Update image in task definition
+        id: update-task-def
+        run: |
+          echo "Updating task definition with image: $ECR_IMAGE_URI_SHA"
+          # Create new task def content, preserving other values
+          # Ensure ECS_CONTAINER_NAME matches the name of the container definition in your task
+          jq --arg IMAGE_URI "$ECR_IMAGE_URI_SHA" --arg CONTAINER_NAME "${{ env.ECS_CONTAINER_NAME }}" \
+          '.containerDefinitions[] | select(.name == $CONTAINER_NAME).image = $IMAGE_URI | .family = "${{ env.ECS_TASK_DEFINITION_FAMILY }}"' \
+          task-definition.json > new-task-definition.json
+
+          # Remove fields not allowed for new task definition registration
+          # These are: taskDefinitionArn, revision, status, requiresAttributes (with compatibilities), compatibilities, registeredAt, registeredBy, deregisteredAt
+          # For simplicity, we create a new task definition by only selecting allowed fields for registration
+          # See: https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_RegisterTaskDefinition.html
+          jq '{
+            family: .family,
+            taskRoleArn: .taskRoleArn,
+            executionRoleArn: .executionRoleArn,
+            networkMode: .networkMode,
+            containerDefinitions: .containerDefinitions,
+            volumes: .volumes,
+            placementConstraints: .placementConstraints,
+            requiresCompatibilities: .requiresCompatibilities,
+            cpu: .cpu,
+            memory: .memory,
+            tags: .tags,
+            pidMode: .pidMode,
+            ipcMode: .ipcMode,
+            proxyConfiguration: .proxyConfiguration,
+            inferenceAccelerators: .inferenceAccelerators,
+            ephemeralStorage: .ephemeralStorage,
+            runtimePlatform: .runtimePlatform
+          } | del(..|nulls)' new-task-definition.json > final-task-definition.json
+
+          echo "NEW_TASK_DEFINITION_FILE=final-task-definition.json" >> $GITHUB_ENV
+          echo "Updated task definition content:"
+          cat final-task-definition.json
+
+      - name: Register new ECS task definition
+        id: register-task-def
+        run: |
+          NEW_TASK_DEF_ARN=$(aws ecs register-task-definition --cli-input-json file://${{ env.NEW_TASK_DEFINITION_FILE }} --region ${{ env.AWS_REGION }} --query taskDefinition.taskDefinitionArn --output text)
+          if [ -z "$NEW_TASK_DEF_ARN" ]; then
+            echo "Failed to register new task definition."
+            exit 1
+          fi
+          echo "NEW_TASK_DEF_ARN=$NEW_TASK_DEF_ARN" >> $GITHUB_ENV
+          echo "Registered new task definition: $NEW_TASK_DEF_ARN"
+
+      - name: Update ECS service with new task definition
+        id: update-service
+        run: |
+          echo "Updating ECS service ${{ env.ECS_SERVICE_NAME }} in cluster ${{ env.ECS_CLUSTER_NAME }} to use task definition $NEW_TASK_DEF_ARN"
+          aws ecs update-service --cluster ${{ env.ECS_CLUSTER_NAME }} --service ${{ env.ECS_SERVICE_NAME }} --task-definition ${{ env.NEW_TASK_DEF_ARN }} --region ${{ env.AWS_REGION }} --query service.serviceName --output text
+          echo "ECS service update initiated."
+
+      - name: Wait for ECS service deployment to stabilize (optional)
+        run: |
+          echo "Waiting for service deployment to stabilize..."
+          aws ecs wait services-stable --cluster ${{ env.ECS_CLUSTER_NAME }} --services ${{ env.ECS_SERVICE_NAME }} --region ${{ env.AWS_REGION }}
+          echo "Service deployment stable."
+        # This step is optional but recommended to ensure the deployment completes successfully before the workflow finishes.
+        # It can take several minutes.
+
+      - name: Clean up task definition files
+        if: always() # Always run cleanup
+        run: |
+          rm -f task-definition.json new-task-definition.json final-task-definition.json
+          echo "Cleaned up temporary task definition files."

--- a/README.md
+++ b/README.md
@@ -1,0 +1,115 @@
+# Project Title (Replace with Actual Project Title)
+
+This is the main README for the project. It provides an overview of the project structure, setup, and deployment.
+
+## Table of Contents
+
+- [Project Structure](#project-structure)
+- [Local Development](#local-development)
+- [AWS Infrastructure & Deployment](#aws-infrastructure--deployment)
+- [Backend](#backend)
+- [Frontend](#frontend)
+- [Contributing](#contributing)
+- [License](#license)
+
+## Project Structure
+
+Briefly describe the main directories and their purpose:
+*   `/backend`: Contains the Spring Boot Kotlin backend API.
+*   `/front`: Contains the frontend application.
+*   `/infrastructure`: Contains Terraform code for AWS infrastructure.
+*   `/docker`: Contains Docker configurations for local development (e.g., localstack, database).
+*   `/otel`: OpenTelemetry collector configuration.
+*   `/fluent-bit`: Fluent Bit configuration for log aggregation.
+*   `/traefik`: Traefik proxy configuration for local development.
+
+## Local Development
+
+### Prerequisites
+*   Docker and Docker Compose
+*   JDK (version specified in `backend/api/Dockerfile`, e.g., Corretto 21)
+*   Node.js and pnpm (for frontend development, version in `front/app/package.json`)
+*   `make` (optional, for using Makefile shortcuts)
+
+### Running Locally with Docker Compose
+The easiest way to run the entire application stack (backend, frontend, database, etc.) locally is using Docker Compose:
+```bash
+# Create a .env file from the example if you haven't already
+# cp .env.example .env
+# Update .env with your local configurations if needed
+
+docker-compose up --build
+```
+This will:
+*   Build the backend API Docker image.
+*   Start all services defined in `docker-compose.yaml`, including the database, API, frontend (if configured), Traefik, OpenTelemetry collector, and Fluent Bit.
+*   The API will typically be accessible at `http://localhost:8080` or via Traefik at `http://localhost`.
+*   The frontend (if served by Docker Compose) will be accessible at its configured port (e.g., `http://localhost:3000`).
+
+### Running Backend Independently
+To run the backend API directly (e.g., from your IDE or using Gradle):
+1.  Ensure you have a PostgreSQL database running and accessible. You can use the one from `docker-compose up db` or a separate instance.
+2.  Set the required environment variables for database connection (`DB_URL`, `DB_USER`, `DB_PASSWORD`) and any other necessary configurations (see `.env.example` or `backend/api/Dockerfile`).
+3.  Navigate to the backend directory:
+    ```bash
+    cd backend/api
+    ./gradlew bootRun
+    ```
+
+### Running Frontend Independently
+Refer to the frontend's README at `front/app/README.md` for specific instructions on local development. Typically:
+```bash
+cd front/app
+pnpm install
+pnpm dev
+```
+
+## AWS Infrastructure & Deployment
+
+### Overview
+The API is designed to be deployed to Amazon Web Services (AWS). The infrastructure leverages services like Elastic Container Service (ECS) for running the containerized application, Application Load Balancer (ALB) for traffic distribution, Elastic Container Registry (ECR) for Docker image storage, and Virtual Private Cloud (VPC) for network isolation.
+
+### Infrastructure Provisioning
+The AWS infrastructure is managed using Terraform.
+
+*   **API Infrastructure**: Detailed information on setting up the core API infrastructure (VPC, ECR, ECS, ALB, etc.) can be found in the dedicated README:
+    *   [API Infrastructure Setup Guide](./infrastructure/aws/resources/api/README.md)
+*   **Cognito**: User authentication and management are handled by AWS Cognito. The Terraform configuration for Cognito is managed separately.
+    *   See the Cognito infrastructure directory: [./infrastructure/aws/resources/cognito/](./infrastructure/aws/resources/cognito/)
+
+### Deployment Process
+Deployments to AWS are automated using GitHub Actions. The workflow is defined in `.github/workflows/docker-image-push.yml`.
+
+*   **Trigger**: Pushing changes to the `main` branch automatically triggers the deployment pipeline.
+*   **Process**:
+    1.  The backend API's Docker image is built.
+    2.  The image is pushed to Amazon ECR.
+    3.  The Amazon ECS service is updated with the new Docker image, which triggers a new deployment of the application.
+*   **Required Secrets for GitHub Actions**: The workflow requires the following secrets to be configured in the GitHub repository settings:
+    *   `AWS_ACCESS_KEY_ID`
+    *   `AWS_SECRET_ACCESS_KEY`
+    *   `AWS_REGION`
+    *   `ECR_REPOSITORY_NAME` (The name of the ECR repository)
+    *   `ECS_CLUSTER_NAME` (The name of the ECS cluster)
+    *   `ECS_SERVICE_NAME` (The name of the ECS service)
+    *   `ECS_TASK_DEFINITION_FAMILY` (The family name of the ECS task definition)
+    *   `ECS_CONTAINER_NAME` (The name of the container defined in the task definition)
+
+## Backend
+The backend is a Spring Boot application written in Kotlin.
+*   **Source Code**: `backend/`
+*   **API Definition**: GraphQL schema at `schema.graphql`.
+*   **Key Technologies**: Spring Boot, Kotlin, Gradle, GraphQL (DGS), PostgreSQL.
+
+## Frontend
+The frontend is a [Specify Frontend Technology, e.g., React/Vue/Angular] application.
+*   **Source Code**: `front/app/`
+*   **Key Technologies**: [Specify, e.g., TypeScript, React, Vite, Tailwind CSS]
+*   Refer to `front/app/README.md` for more details.
+
+
+## Contributing
+[Information about contributing to the project, coding standards, pull request process, etc.]
+
+## License
+[Specify the project license, e.g., MIT, Apache 2.0]

--- a/README.md
+++ b/README.md
@@ -67,15 +67,15 @@ pnpm dev
 ## AWS Infrastructure & Deployment
 
 ### Overview
-The API is designed to be deployed to Amazon Web Services (AWS). The infrastructure leverages services like Elastic Container Service (ECS) for running the containerized application, Application Load Balancer (ALB) for traffic distribution, Elastic Container Registry (ECR) for Docker image storage, and Virtual Private Cloud (VPC) for network isolation.
+The API is designed to be deployed to Amazon Web Services (AWS). The infrastructure leverages services like Elastic Container Service (ECS) for running the containerized application, Application Load Balancer (ALB) for traffic distribution, Elastic Container Registry (ECR) for Docker image storage, and Virtual Private Cloud (VPC) for network isolation. **The API is protected by Amazon Cognito authentication at the Application Load Balancer level, meaning access to API endpoints requires users to authenticate via the configured Cognito User Pool.** All traffic is enforced to use HTTPS.
 
 ### Infrastructure Provisioning
 The AWS infrastructure is managed using Terraform.
 
-*   **API Infrastructure**: Detailed information on setting up the core API infrastructure (VPC, ECR, ECS, ALB, etc.) can be found in the dedicated README:
+*   **API Infrastructure**: Detailed information on setting up the core API infrastructure (VPC, ECR, ECS, ALB, etc.) can be found in the dedicated README. **This setup includes the integration of the Application Load Balancer with Amazon Cognito for authentication.**
     *   [API Infrastructure Setup Guide](./infrastructure/aws/resources/api/README.md)
-*   **Cognito**: User authentication and management are handled by AWS Cognito. The Terraform configuration for Cognito is managed separately.
-    *   See the Cognito infrastructure directory: [./infrastructure/aws/resources/cognito/](./infrastructure/aws/resources/cognito/)
+*   **Cognito**: User authentication and management are handled by AWS Cognito. The Terraform configuration for Cognito is managed separately and must be deployed *before* the API infrastructure.
+    *   See the Cognito infrastructure directory: [./infrastructure/aws/resorces/cognito/](./infrastructure/aws/resorces/cognito/) (Note: "resorces" is the actual directory name with a typo).
 
 ### Deployment Process
 Deployments to AWS are automated using GitHub Actions. The workflow is defined in `.github/workflows/docker-image-push.yml`.

--- a/README.md
+++ b/README.md
@@ -31,22 +31,11 @@ Briefly describe the main directories and their purpose:
 *   Node.js and pnpm (for frontend development, version in `front/app/package.json`)
 *   `make` (optional, for using Makefile shortcuts)
 
-### Running Locally with Docker Compose
-The easiest way to run the entire application stack (backend, frontend, database, etc.) locally is using Docker Compose:
-```bash
-# Create a .env file from the example if you haven't already
-# cp .env.example .env
-# Update .env with your local configurations if needed
+### Legacy Local Development (Manual Setup)
 
-docker-compose up --build
-```
-This will:
-*   Build the backend API Docker image.
-*   Start all services defined in `docker-compose.yaml`, including the database, API, frontend (if configured), Traefik, OpenTelemetry collector, and Fluent Bit.
-*   The API will typically be accessible at `http://localhost:8080` or via Traefik at `http://localhost`.
-*   The frontend (if served by Docker Compose) will be accessible at its configured port (e.g., `http://localhost:3000`).
+This section describes running services independently or with a simpler Docker Compose setup that does not involve LocalStack for AWS service emulation.
 
-### Running Backend Independently
+#### Running Backend Independently
 To run the backend API directly (e.g., from your IDE or using Gradle):
 1.  Ensure you have a PostgreSQL database running and accessible. You can use the one from `docker-compose up db` or a separate instance.
 2.  Set the required environment variables for database connection (`DB_URL`, `DB_USER`, `DB_PASSWORD`) and any other necessary configurations (see `.env.example` or `backend/api/Dockerfile`).
@@ -63,6 +52,109 @@ cd front/app
 pnpm install
 pnpm dev
 ```
+
+## Local Development with LocalStack (Recommended for Cloud Features)
+
+This project supports a local development environment that simulates AWS services using LocalStack. This allows for testing cloud interactions locally, reducing reliance on shared development AWS accounts and providing a more consistent development experience.
+
+### Prerequisites
+*   Docker and Docker Compose installed.
+*   (Optional but Recommended) AWS CLI (`aws`) installed for interacting with LocalStack. The `awslocal` command (part of the `awscli-local` package) is used in the initialization script and is the preferred tool for LocalStack interaction. You can install it via `pip install awscli-local`.
+
+### Setup & Configuration
+*   **LocalStack Service:** LocalStack is configured as a service in `docker-compose.yaml`. It's set up to expose common AWS service ports and persist data in `./tmp/localstack`.
+*   **Initialization Script (`docker/localstack/init-aws.sh`):**
+    *   This script automatically provisions a suite of AWS resources inside LocalStack when it starts up.
+    *   Key resources it attempts to create include:
+        *   VPC and Subnets
+        *   ECR Repository (for the application image)
+        *   ECS Cluster
+        *   Cognito User Pool, User Pool Client, and User Pool Domain
+        *   Application Load Balancer (ALB) with an HTTP listener and an experimental HTTPS listener with Cognito authentication
+        *   Target Group for the `app` service
+    *   The script is mounted into LocalStack and executed when the `ready.d` hook is triggered.
+*   **Environment Variables:**
+    *   The `docker-compose.yaml` file sets default AWS configuration for the `app` service to point to LocalStack (e.g., `AWS_ENDPOINT_URL: http://localstack:4566`).
+    *   You can define `AWS_REGION` in your `.env` file if you need to use a region other than the default (`us-east-1`) specified in `docker-compose.yaml` for LocalStack and the `app` service.
+
+### Running the Local Environment with LocalStack
+1.  **Ensure your `.env` file is present.** If not, you might want to copy `.env.example` to `.env` and adjust as needed, though for LocalStack, most AWS credentials in `.env` are overridden by the Docker Compose settings for the `app` service.
+2.  **Start the environment:**
+    ```bash
+    docker-compose up -d
+    ```
+    To view logs from all services (including LocalStack's initialization):
+    ```bash
+    docker-compose up
+    ```
+3.  **Rebuilding services (e.g., if you change `backend/api/Dockerfile`):**
+    ```bash
+    docker-compose build app # Or specific service
+    docker-compose up -d
+    ```
+    Or to rebuild all:
+    ```bash
+    docker-compose build && docker-compose up -d
+    ```
+    On the first startup, or after deleting `./tmp/localstack`, LocalStack will run the `init-aws.sh` script, which can take a few minutes.
+
+### Accessing Services
+*   **Application (`app` service):**
+    *   The `init-aws.sh` script attempts to set up an Application Load Balancer (ALB) within LocalStack. The script outputs the local ALB DNS name (e.g., `http://local-app-alb.localhost.localstack.cloud:4566` or similar). However, directly accessing this DNS name from your host machine might require additional host file configuration or specific LocalStack networking setups.
+    *   **Primary access for the API will likely be via `http://localhost:4566` for the ALB, using a Host header matching the ALB name, or through specific service endpoints if LocalStack's ALB routing doesn't work as expected out-of-the-box.**
+    *   See the "Connecting LocalStack ALB to the `app` Service" section below for important caveats.
+*   **LocalStack General Endpoint / Web UI:**
+    *   LocalStack services are accessible via the main endpoint: `http://localhost:4566`.
+    *   LocalStack used to have a basic Web UI. For LocalStack 3.0+, a more advanced UI is part of LocalStack Pro or LocalStack Desktop. You can check `http://localhost:4566/` for any available default dashboard.
+*   **Cognito (Local):**
+    *   The `init-aws.sh` script outputs `LOCAL_COGNITO_USER_POOL_ID`, `LOCAL_COGNITO_CLIENT_ID`, and `LOCAL_COGNITO_DOMAIN_PREFIX`. These can be used with `awslocal` to interact with the local Cognito service.
+    *   A typical Cognito login form URL pattern (might vary with LocalStack versions and setup) is:
+        `http://localhost:4566/cognito-idp/login?response_type=code&client_id=<YOUR_LOCAL_CLIENT_ID>&redirect_uri=<YOUR_APP_CALLBACK_URL_CONFIGURED_IN_COGNITO_CLIENT>&scope=openid+profile+email`
+        (Note: The hostname for the Cognito UI might be `localhost.localstack.cloud` or require specific configuration. Refer to LocalStack's documentation for the exact structure of the hosted UI URL for Cognito.)
+
+### Interacting with LocalStack AWS Services
+You can use `awslocal` (or `aws` CLI configured with `--endpoint-url=http://localhost:4566`) to inspect and manage resources within LocalStack.
+*   **Examples:**
+    ```bash
+    awslocal s3 ls --region ${AWS_REGION:-us-east-1}
+    awslocal ecr describe-repositories --region ${AWS_REGION:-us-east-1}
+    awslocal cognito-idp list-user-pools --max-results 10 --region ${AWS_REGION:-us-east-1}
+    awslocal elbv2 describe-load-balancers --region ${AWS_REGION:-us-east-1}
+    awslocal elbv2 describe-target-groups --region ${AWS_REGION:-us-east-1}
+    ```
+
+### Connecting LocalStack ALB to the `app` Service (Important Caveat)
+A known challenge with the current setup is the automatic registration of the `app` service (running as a Docker container) with the Target Group created by the LocalStack ALB.
+*   The `init-aws.sh` script creates an ALB and a Target Group (typically named `local-app-tg`).
+*   However, the `app` container's IP address (on the Docker network) is not automatically registered with this Target Group by the current script.
+*   **Manual Registration Steps (after `docker-compose up`):**
+    1.  Identify the `app` container's ID: `docker ps`
+    2.  Find the `app` container's IP address on the relevant Docker network (usually the network named `<project_name>_default`):
+        ```bash
+        docker inspect <app_container_id_or_name> | jq -r '.[0].NetworkSettings.Networks | to_entries[0].value.IPAddress'
+        # Replace <project_name> if your Docker network has a different name.
+        ```
+    3.  Get the Target Group ARN (output by `init-aws.sh` during startup, or use `awslocal elbv2 describe-target-groups`).
+    4.  Register the `app` container with the Target Group:
+        ```bash
+        awslocal elbv2 register-targets \
+          --target-group-arn <target_group_arn_from_init_script_or_awslocal> \
+          --targets Id=<app_container_ip_address>,Port=8080 \
+          --region ${AWS_REGION:-us-east-1}
+        ```
+*   **Alternative for Simpler Testing:** If you don't need to test the full ALB/Cognito flow, you can expose the `app` service's port directly in `docker-compose.yaml` (e.g., `ports: - "8081:8080"`) and access it via `http://localhost:8081`, bypassing the LocalStack ALB.
+
+### Limitations & Known Issues
+*   **ALB with Cognito Authentication:** The `authenticate-cognito` action for ALB listeners is an advanced feature. Its simulation in LocalStack (especially in the free tier) might be incomplete or behave differently than real AWS. The `init-aws.sh` script attempts this setup, but it requires thorough testing.
+*   **HTTPS for ALB:** The `init-aws.sh` script attempts to set up an HTTPS listener using a placeholder certificate ARN (`arn:aws:acm:us-east-1:000000000000:certificate/placeholder-cert-arn`). For true HTTPS locally with valid certificates, significant additional configuration would be needed, which is beyond the scope of the current LocalStack setup. Expect certificate errors if accessing the HTTPS endpoint directly.
+*   **Service Discovery:** DNS resolution for services within LocalStack (like ALB DNS names) might not work automatically from your host machine without additional configuration (e.g., editing `/etc/hosts` or using LocalStack's DNS server if available and configured).
+*   **Persistence:** LocalStack is configured with `PERSISTENCE=1` and mounts `./tmp/localstack` to `/var/lib/localstack`. This means AWS resource state *should* be saved across `docker-compose down` and `up`. To reset LocalStack's state completely, delete the `./tmp/localstack` directory.
+
+### Troubleshooting
+*   **Check LocalStack Logs:** `docker-compose logs localstack`. Look for output from `init-aws.sh` and any service errors.
+*   **Check `app` Service Logs:** `docker-compose logs app`.
+*   **Inspect Docker Networks:** `docker network ls`, `docker network inspect <network_name>`.
+*   **Ensure `init-aws.sh` is Executable:** It should have been made executable in previous steps (`chmod +x docker/localstack/init-aws.sh`).
 
 ## AWS Infrastructure & Deployment
 

--- a/backend/api/Dockerfile
+++ b/backend/api/Dockerfile
@@ -9,7 +9,36 @@ ENV DB_USER $DB_USER
 ENV DB_PASSWORD $DB_PASSWORD
 
 WORKDIR /build
-COPY . .
+
+# Copy Gradle wrapper, settings, and root build file
+COPY gradlew gradlew.bat ./
+COPY gradle ./gradle
+COPY settings.gradle.kts ./
+COPY build.gradle.kts ./
+COPY gradle.properties ./
+
+# Copy backend project build files to define project structure
+COPY backend/api/build.gradle.kts backend/api/build.gradle.kts
+COPY backend/applications/build.gradle.kts backend/applications/build.gradle.kts
+COPY backend/core/build.gradle.kts backend/core/build.gradle.kts
+COPY backend/domains/build.gradle.kts backend/domains/build.gradle.kts
+COPY backend/infrastructure/build.gradle.kts backend/infrastructure/build.gradle.kts
+COPY backend/testCore/build.gradle.kts backend/testCore/build.gradle.kts
+
+# Copy the schema for code generation
+COPY schema.graphql ./schema.graphql
+
+# It's often better to download dependencies as a separate layer
+# RUN ./gradlew --no-daemon :backend:api:dependencies
+
+# Copy source code
+COPY backend/api/src backend/api/src
+COPY backend/applications/src backend/applications/src
+COPY backend/core/src backend/core/src
+COPY backend/domains/src backend/domains/src
+COPY backend/infrastructure/src backend/infrastructure/src
+# testCore source is not needed for the final api.jar, only its build.gradle.kts for project structure
+
 RUN ./gradlew backend:api:bootJar
 
 FROM amazoncorretto:21.0.3
@@ -21,18 +50,24 @@ ENV OTEL_EXPORTER_OTLP_ENDPOINT http://otel-collector:4317
 ENV OTEL_EXPORTER_OTLP_TRACES_ENDPOINT http://otel-collector:4317
 ENV OTEL_EXPORTER_OTLP_METRICS_ENDPOINT http://otel-collector:4317
 ENV OTEL_EXPORTER_OTLP_PROTOCOL grpc
+# Note: service.instance.id=petclinic seems to be a hardcoded value from a tutorial.
+# Consider making this dynamic via an environment variable if this Dockerfile is to be reused for other services.
 ENV OTEL_RESOURCE_ATTRIBUTES service.instance.id=petclinic,INSTANA_PLUGIN=jvm
 
-RUN yum update -y \
-    && yum install -y shadow-utils \
-    && yum clean all
+# shadow-utils is not needed for runtime, groupadd/useradd are part of coreutils (already in the base image)
+# RUN yum update -y \
+#     && yum install -y shadow-utils \
+#     && yum clean all
 
 RUN mkdir -p /app/jar
 
-RUN groupadd --system javauser && useradd -r -s /bin/false -g javauser javauser
+RUN groupadd --system javauser && useradd --system --no-create-home --gid javauser --shell /bin/false javauser
 
 
 COPY --from=0 /build/backend/api/build/libs/api.jar /app/jar/api.jar
+# schema.graphql is copied from the build stage. Ensure it's actually needed by the runtime application.
+# If only used during build (e.g. by DGS codegen), it might not be needed in the final image.
+# For now, keeping it as per original Dockerfile's intent.
 COPY --from=0 /build/schema.graphql /schema.graphql
 
 WORKDIR /app

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -57,10 +57,25 @@ services:
       - "traefik.http.routers.spring-app.rule=Host(`localhost`)"
       - "traefik.http.services.spring-app.loadbalancer.server.port=8080"
     depends_on:
-      - db
-      - traefik
-      - fluent-bit
-      - otel-collector
+      db:
+        condition: service_healthy # Assuming db's healthcheck is reliable
+      traefik:
+        condition: service_started # Traefik doesn't have a healthcheck here
+      fluent-bit:
+        condition: service_started # Fluent-bit doesn't have a healthcheck here
+      otel-collector:
+        condition: service_started # Otel-collector doesn't have a healthcheck here
+      localstack:
+        condition: service_healthy
+    environment:
+      # Environment variables for Spring Boot app if needed, e.g. DB connection already handled by .env
+      # AWS SDK specific environment variables to point to LocalStack
+      AWS_ENDPOINT_URL: http://localstack:4566
+      AWS_ACCESS_KEY_ID: test
+      AWS_SECRET_ACCESS_KEY: test
+      AWS_REGION: ${AWS_REGION:-us-east-1} # Ensure AWS_REGION is defined in .env or defaults here
+      # Example for specific service endpoint override if needed by the application
+      # COGNITO_IDP_ENDPOINT_OVERRIDE: http://localstack:4566
     logging:
       driver: fluentd
       options:
@@ -74,6 +89,32 @@ services:
       - "24224:24224"
     env_file:
       - .env
+  localstack:
+    container_name: localstack
+    image: localstack/localstack:3.0
+    ports:
+      - "4566:4566"             # Main LocalStack Gateway
+      - "4510-4559:4510-4559"   # External services port range (legacy)
+    environment:
+      SERVICES: ec2,elbv2,ecs,ecr,cognito-idp,s3,iam,sts,cloudformation
+      DEBUG: 1
+      PERSISTENCE: 1
+      DOCKER_HOST: unix:///var/run/docker.sock
+      DEFAULT_REGION: ${AWS_REGION:-us-east-1}
+      SKIP_SSL_CERT_DOWNLOAD: 1
+      LS_LOG: trace # More verbose logging, can be 'debug', 'info', 'warn', 'error'
+    volumes:
+      - ./tmp/localstack:/var/lib/localstack # For persistence
+      - ./docker/localstack/init-aws.sh:/etc/localstack/init/ready.d/init-aws.sh # Initialization script
+      - /var/run/docker.sock:/var/run/docker.sock # To allow LocalStack to manage Docker containers
+    healthcheck:
+      test: ["CMD-SHELL", "awslocal health | jq -e '.services | all(.status == \"available\")' || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s # Give LocalStack time to start all services
+    depends_on:
+      - fluent-bit # Optional: if localstack logs should go through fluent-bit (needs config)
   otel-collector:
     image: otel/opentelemetry-collector:0.113.0
     command: ["--config=/etc/otel-collector-config.yaml"]
@@ -87,4 +128,9 @@ services:
       - "13133:13133"
 volumes:
   db-store:
-  moto-aws-local:
+  # moto-aws-local: # This seems like a leftover or for a different setup, not used by LocalStack directly here
+  localstack-data: # More explicit name for LocalStack persistence volume if not using host bind
+    driver: local # This line is not strictly necessary if you use the host bind "./tmp/localstack"
+
+# Note: The volume `./tmp/localstack` needs to exist or Docker will create it as root.
+# Consider adding a .mkdir command or ensuring it's in .gitignore if it's truly temporary.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -50,10 +50,6 @@ services:
     build:
       context: .
       dockerfile: "./backend/api/Dockerfile"
-      args:
-        - DB_URL=${DB_USER}
-        - DB_USER=${DB_PASSWORD}
-        - DB_PASSWORD=${DB_NAME}
     env_file:
       - .env
     labels:

--- a/docker/localstack/init-aws.sh
+++ b/docker/localstack/init-aws.sh
@@ -1,0 +1,172 @@
+#!/bin/bash
+echo "LocalStack init script started."
+set -e # Exit on error for most commands
+
+DEFAULT_REGION=${AWS_REGION:-us-east-1}
+APP_NAME="my-app" # Should match var.app_name if possible
+ENVIRONMENT="local" # Should match var.environment
+
+echo "Using region: $DEFAULT_REGION"
+echo "App name: $APP_NAME"
+echo "Environment: $ENVIRONMENT"
+
+# 1. Network (VPC, Subnets) - Optional but good practice
+echo "Creating VPC and Subnets..."
+VPC_ID=$(awslocal ec2 create-vpc --cidr-block 10.0.0.0/16 --query Vpc.VpcId --output text)
+echo "VPC_ID: $VPC_ID"
+awslocal ec2 create-tags --resources $VPC_ID --tags Key=Name,Value=$ENVIRONMENT-vpc
+
+SUBNET_PUBLIC_A_ID=$(awslocal ec2 create-subnet --vpc-id $VPC_ID --cidr-block 10.0.1.0/24 --availability-zone ${DEFAULT_REGION}a --query Subnet.SubnetId --output text)
+echo "SUBNET_PUBLIC_A_ID: $SUBNET_PUBLIC_A_ID"
+awslocal ec2 create-tags --resources $SUBNET_PUBLIC_A_ID --tags Key=Name,Value=$ENVIRONMENT-public-subnet-a
+
+SUBNET_PUBLIC_B_ID=$(awslocal ec2 create-subnet --vpc-id $VPC_ID --cidr-block 10.0.2.0/24 --availability-zone ${DEFAULT_REGION}b --query Subnet.SubnetId --output text)
+echo "SUBNET_PUBLIC_B_ID: $SUBNET_PUBLIC_B_ID"
+awslocal ec2 create-tags --resources $SUBNET_PUBLIC_B_ID --tags Key=Name,Value=$ENVIRONMENT-public-subnet-b
+
+# (Add private subnets if your local setup specifically needs to test private networking)
+
+# 2. ECR Repository
+echo "Creating ECR repository..."
+ECR_REPO_NAME="${ENVIRONMENT}-${APP_NAME}"
+awslocal ecr create-repository --repository-name "$ECR_REPO_NAME" --region "$DEFAULT_REGION" || echo "ECR repo $ECR_REPO_NAME likely already exists."
+echo "ECR Repository: $ECR_REPO_NAME"
+
+# 3. ECS Cluster
+echo "Creating ECS cluster..."
+ECS_CLUSTER_NAME="${ENVIRONMENT}-ecs-cluster"
+awslocal ecs create-cluster --cluster-name "$ECS_CLUSTER_NAME" --region "$DEFAULT_REGION" || echo "ECS cluster $ECS_CLUSTER_NAME likely already exists."
+echo "ECS Cluster: $ECS_CLUSTER_NAME"
+
+# 4. Cognito User Pool, Client, and Domain
+echo "Creating Cognito User Pool, Client, and Domain..."
+COGNITO_USER_POOL_NAME="${ENVIRONMENT}-user-pool"
+USER_POOL_ID=$(awslocal cognito-idp create-user-pool --pool-name "$COGNITO_USER_POOL_NAME" --query UserPool.Id --output text --region "$DEFAULT_REGION")
+echo "Cognito User Pool ID: $USER_POOL_ID"
+
+if [ -z "$USER_POOL_ID" ]; then
+  echo "Failed to create Cognito User Pool. Exiting."
+  exit 1
+fi
+
+COGNITO_CLIENT_NAME="${ENVIRONMENT}-app-client"
+USER_POOL_CLIENT_ID=$(awslocal cognito-idp create-user-pool-client \
+  --user-pool-id "$USER_POOL_ID" \
+  --client-name "$COGNITO_CLIENT_NAME" \
+  --no-generate-secret \
+  --explicit-auth-flows ADMIN_NO_SRP_AUTH USER_PASSWORD_AUTH \
+  --callback-urls "http://localhost:80/oauth2/idpresponse" "http://localhost/callback" \ # Placeholder callback
+  --logout-urls "http://localhost/logout" \ # Placeholder logout
+  --allowed-oauth-flows code id_token \
+  --allowed-oauth-scopes email openid profile \
+  --supported-identity-providers COGNITO \
+  --query UserPoolClient.ClientId --output text --region "$DEFAULT_REGION")
+echo "Cognito User Pool Client ID: $USER_POOL_CLIENT_ID"
+
+if [ -z "$USER_POOL_CLIENT_ID" ]; then
+  echo "Failed to create Cognito User Pool Client. Exiting."
+  exit 1
+fi
+
+COGNITO_DOMAIN_PREFIX="${ENVIRONMENT}-${APP_NAME}-auth"
+awslocal cognito-idp create-user-pool-domain --user-pool-id "$USER_POOL_ID" --domain "$COGNITO_DOMAIN_PREFIX" --region "$DEFAULT_REGION"
+echo "Cognito Domain: ${COGNITO_DOMAIN_PREFIX}.auth.${DEFAULT_REGION}.amazoncognito.com (Note: LocalStack might use a different URL structure)"
+
+# Output Cognito details for potential use by the application or testing
+echo "LOCAL_COGNITO_USER_POOL_ID=$USER_POOL_ID"
+echo "LOCAL_COGNITO_CLIENT_ID=$USER_POOL_CLIENT_ID"
+echo "LOCAL_COGNITO_DOMAIN_PREFIX=$COGNITO_DOMAIN_PREFIX"
+
+# 5. Application Load Balancer (ALB) and Target Group
+# This is the most complex part and might have limitations in LocalStack.
+echo "Creating ALB, Target Group, and Listener..."
+
+ALB_NAME="${ENVIRONMENT}-app-alb"
+TG_NAME="${ENVIRONMENT}-app-tg"
+
+# Create Security Group for ALB (allow all for local simplicity)
+SG_ALB_ID=$(awslocal ec2 create-security-group --group-name "${ENVIRONMENT}-alb-sg" --description "ALB SG for local" --vpc-id "$VPC_ID" --query GroupId --output text)
+echo "ALB Security Group ID: $SG_ALB_ID"
+# Allow inbound HTTP/HTTPS (for local, often all ports are open by default from host)
+awslocal ec2 authorize-security-group-ingress --group-id "$SG_ALB_ID" --protocol tcp --port 80 --cidr 0.0.0.0/0
+awslocal ec2 authorize-security-group-ingress --group-id "$SG_ALB_ID" --protocol tcp --port 443 --cidr 0.0.0.0/0
+
+
+ALB_ARN=$(awslocal elbv2 create-load-balancer \
+  --name "$ALB_NAME" \
+  --subnets "$SUBNET_PUBLIC_A_ID" "$SUBNET_PUBLIC_B_ID" \
+  --security-groups "$SG_ALB_ID" \
+  --scheme internet-facing \
+  --type application \
+  --query 'LoadBalancers[0].LoadBalancerArn' --output text --region "$DEFAULT_REGION" 2>/dev/null || echo "Failed to create ALB. This might be a LocalStack limitation or misconfiguration.")
+
+if [ -z "$ALB_ARN" ]; then
+  echo "ALB creation failed. Skipping ALB listener and target group setup."
+else
+  echo "ALB ARN: $ALB_ARN"
+  ALB_DNS_NAME=$(awslocal elbv2 describe-load-balancers --load-balancer-arns "$ALB_ARN" --query 'LoadBalancers[0].DNSName' --output text --region "$DEFAULT_REGION")
+  echo "ALB DNS Name (LocalStack): $ALB_DNS_NAME" # This will be a LocalStack internal DNS
+
+  TARGET_GROUP_ARN=$(awslocal elbv2 create-target-group \
+    --name "$TG_NAME" \
+    --protocol HTTP \
+    --port 8080 \ # Port your 'app' service runs on
+    --vpc-id "$VPC_ID" \
+    --target-type ip \
+    --health-check-protocol HTTP \
+    --health-check-port traffic-port \
+    --health-check-path /actuator/health \ # Assuming Spring Boot actuator
+    --query 'TargetGroups[0].TargetGroupArn' --output text --region "$DEFAULT_REGION")
+  echo "Target Group ARN: $TARGET_GROUP_ARN"
+
+  # Attempt to create HTTPS listener with Cognito authentication
+  # This requires a certificate. For LocalStack, we often skip cert validation or use a dummy one.
+  # LocalStack might not fully support `authenticate-cognito` action type.
+  # We will create a simple HTTP listener first, then attempt HTTPS if possible.
+
+  echo "Creating HTTP listener (port 80) forwarding to Target Group $TG_NAME..."
+  awslocal elbv2 create-listener \
+    --load-balancer-arn "$ALB_ARN" \
+    --protocol HTTP \
+    --port 80 \
+    --default-actions Type=forward,TargetGroupArn="$TARGET_GROUP_ARN" \
+    --region "$DEFAULT_REGION" || echo "Failed to create HTTP listener."
+
+  echo "Attempting to create HTTPS listener (port 443) with Cognito Auth..."
+  # For HTTPS, ACM certificate is needed. In LocalStack, this is often tricky.
+  # We might need to create a dummy cert or LocalStack might have a default one.
+  # The `authenticate-cognito` action might not be fully supported.
+  # This part is experimental for LocalStack.
+  USER_POOL_ARN="arn:aws:cognito-idp:$DEFAULT_REGION:000000000000:userpool/$USER_POOL_ID" # Construct User Pool ARN for LocalStack
+
+  set +e # Do not exit on error for this experimental part
+  awslocal elbv2 create-listener \
+    --load-balancer-arn "$ALB_ARN" \
+    --protocol HTTPS \
+    --port 443 \
+    --certificates CertificateArn=arn:aws:acm:$DEFAULT_REGION:000000000000:certificate/placeholder-cert-arn \ # Placeholder/dummy cert ARN
+    --ssl-policy ELBSecurityPolicy-2016-08 \
+    --default-actions \
+      "[{\"Type\":\"authenticate-cognito\",\"Order\":1,\"AuthenticateCognitoConfig\":{\"UserPoolArn\":\"$USER_POOL_ARN\",\"UserPoolClientId\":\"$USER_POOL_CLIENT_ID\",\"UserPoolDomain\":\"$COGNITO_DOMAIN_PREFIX\",\"OnUnauthenticatedRequest\":\"authenticate\",\"Scope\":\"openid\",\"SessionCookieName\":\"AWSELBAuthSessionCookie-0\"}},{\"Type\":\"forward\",\"Order\":2,\"TargetGroupArn\":\"$TARGET_GROUP_ARN\"}]" \
+    --region "$DEFAULT_REGION"
+  
+  if [ $? -eq 0 ]; then
+    echo "HTTPS listener with Cognito auth action *attempted*. Check LocalStack logs for success/failure."
+  else
+    echo "Failed to create HTTPS listener with Cognito auth. This feature might be limited in LocalStack. Falling back to HTTP only for ALB."
+  fi
+  set -e # Re-enable exit on error
+fi
+
+# (Optional) Create a basic ECS Task Definition and Service if needed for more complete simulation
+# This would involve defining container (pointing to a locally built image) and service config.
+# For now, focus is on ALB + Cognito.
+
+echo "LocalStack init script finished."
+echo "Important LocalStack endpoints/values:"
+echo "  ALB DNS (if created): http://$ALB_DNS_NAME (or use localhost:4566 with ALB name in path/Host header)"
+echo "  Cognito User Pool ID: $USER_POOL_ID"
+echo "  Cognito Client ID: $USER_POOL_CLIENT_ID"
+echo "  Cognito Domain Prefix: $COGNITO_DOMAIN_PREFIX"
+echo "  ECR Repository: $ECR_REPO_NAME (Access via http://localhost:4566)"
+echo "  ECS Cluster: $ECS_CLUSTER_NAME"

--- a/infrastructure/aws/resorces/cognito/main.tf
+++ b/infrastructure/aws/resorces/cognito/main.tf
@@ -17,6 +17,34 @@ terraform {
   }
 }
 
+resource "aws_cognito_user_pool_domain" "e2e_domain" {
+  domain       = "${var.env}-e2e-api-auth" # Using var.env as requested
+  user_pool_id = aws_cognito_user_pool.e2e_user_pool.id
+}
+
+output "user_pool_arn" {
+  description = "ARN of the Cognito User Pool"
+  value       = aws_cognito_user_pool.e2e_user_pool.arn
+}
+
+output "user_pool_client_id" {
+  description = "Client ID of the Cognito User Pool Client"
+  value       = aws_cognito_user_pool_client.e2e_user_pool_client.id
+}
+
+output "user_pool_domain_base_url" {
+  description = "Base URL of the Cognito User Pool Domain (this is the prefix, not the full URL)"
+  # The actual cognito domain will be <domain_prefix>.auth.<region>.amazoncognito.com
+  # The output from aws_cognito_user_pool_domain.domain is just the prefix.
+  # The ALB needs just the prefix.
+  value       = aws_cognito_user_pool_domain.e2e_domain.domain
+}
+
+output "user_pool_id" {
+  description = "ID of the Cognito User Pool"
+  value       = aws_cognito_user_pool.e2e_user_pool.id
+}
+
 provider "aws" {
   region = var.aws_region
 }

--- a/infrastructure/aws/resources/api/README.md
+++ b/infrastructure/aws/resources/api/README.md
@@ -2,13 +2,15 @@
 
 ## Overview
 
-This Terraform module provisions the AWS infrastructure for the backend API. It sets up a Virtual Private Cloud (VPC) with public and private subnets, an Elastic Container Registry (ECR) for storing Docker images, an Elastic Container Service (ECS) cluster with a Fargate service for running the API, and an Application Load Balancer (ALB) to distribute traffic to the API. It also includes necessary IAM roles, security groups, and CloudWatch logging.
+This Terraform module provisions the AWS infrastructure for the backend API. It sets up a Virtual Private Cloud (VPC) with public and private subnets, an Elastic Container Registry (ECR) for storing Docker images, an Elastic Container Service (ECS) cluster with a Fargate service for running the API, and an Application Load Balancer (ALB) to distribute traffic to the API. The ALB is configured to use Amazon Cognito for authentication, and all HTTP traffic is redirected to HTTPS. This module also includes necessary IAM roles, security groups, and CloudWatch logging.
 
 ## Prerequisites
 
 *   **Terraform:** Ensure Terraform (version 1.x or later) is installed.
 *   **AWS CLI:** Ensure the AWS CLI is installed and configured with an AWS account and necessary permissions to create the resources defined in this module.
 *   **Terraform Backend:** This module is configured to use an S3 backend for state storage and a DynamoDB table for state locking. These resources (S3 bucket, DynamoDB table) must be created manually before initializing this module. You can refer to a general AWS setup guide for creating these backend resources.
+*   **Cognito Infrastructure:** The Amazon Cognito User Pool and related resources must be provisioned *before* applying this API infrastructure module. This module uses a Terraform remote state data source to fetch outputs (like User Pool ARN, Client ID, and Domain) from the Cognito infrastructure.
+*   **ACM Certificate:** An SSL/TLS certificate must be provisioned in AWS Certificate Manager (ACM) in the same region as the ALB. The ARN of this certificate is required via the `alb_certificate_arn` variable.
 
 ## Directory Structure
 
@@ -35,12 +37,18 @@ Below are some of the key variables defined in `variables.tf`. You can set these
 *   `ecs_service_desired_count`: (number) Desired number of tasks for the ECS service (default: 2).
 *   `health_check_path`: (string) Path for ALB health checks (default: "/health").
 *   `container_environment_variables`: (list(object)) Environment variables for the container.
+*   `cognito_state_bucket`: (string) S3 bucket name for the Cognito module's Terraform state. This is where the state file from your Cognito infrastructure deployment is stored.
+*   `cognito_state_key`: (string) S3 key for the Cognito module's Terraform state file. This is the path to the state file within the `cognito_state_bucket`.
+*   `alb_certificate_arn`: (string) ARN of the ACM certificate for the ALB HTTPS listener. This certificate must be available in AWS Certificate Manager and cover the domain you intend to use for the API.
 
 Create a `terraform.tfvars` file (e.g., `dev.tfvars`) in this directory to specify your variable values:
 ```hcl
-region        = "us-east-1"
-environment   = "dev"
-app_name      = "my-cool-api"
+region                   = "us-east-1"
+environment              = "dev"
+app_name                 = "my-cool-api"
+cognito_state_bucket     = "your-cognito-terraform-state-bucket"
+cognito_state_key        = "cognito/prod/terraform.tfstate" # Adjust path as per your Cognito setup
+alb_certificate_arn      = "arn:aws:acm:us-east-1:123456789012:certificate/your-certificate-id"
 # ... other variables
 ```
 
@@ -72,11 +80,15 @@ terraform plan -var-file=path/to/your-dev.tfvars # Or your specific .tfvars file
 
 ## Applying
 
+Before applying this module, ensure that the Cognito infrastructure (typically managed in `infrastructure/aws/resorces/cognito/`) has been successfully applied and its Terraform state file is available in the S3 bucket and path specified by `cognito_state_bucket` and `cognito_state_key` variables respectively. This module depends on outputs from the Cognito deployment to configure the ALB authentication.
+
 Apply the changes to provision the infrastructure:
 ```bash
 terraform apply -var-file=path/to/your-dev.tfvars
 ```
 Confirm the action by typing `yes` when prompted.
+
+The ALB is configured to enforce HTTPS. All HTTP traffic on port 80 will be automatically redirected to HTTPS on port 443. Access to the API will require authentication via the configured Amazon Cognito User Pool.
 
 ## Destroying
 

--- a/infrastructure/aws/resources/api/README.md
+++ b/infrastructure/aws/resources/api/README.md
@@ -1,0 +1,100 @@
+# API Infrastructure (Terraform)
+
+## Overview
+
+This Terraform module provisions the AWS infrastructure for the backend API. It sets up a Virtual Private Cloud (VPC) with public and private subnets, an Elastic Container Registry (ECR) for storing Docker images, an Elastic Container Service (ECS) cluster with a Fargate service for running the API, and an Application Load Balancer (ALB) to distribute traffic to the API. It also includes necessary IAM roles, security groups, and CloudWatch logging.
+
+## Prerequisites
+
+*   **Terraform:** Ensure Terraform (version 1.x or later) is installed.
+*   **AWS CLI:** Ensure the AWS CLI is installed and configured with an AWS account and necessary permissions to create the resources defined in this module.
+*   **Terraform Backend:** This module is configured to use an S3 backend for state storage and a DynamoDB table for state locking. These resources (S3 bucket, DynamoDB table) must be created manually before initializing this module. You can refer to a general AWS setup guide for creating these backend resources.
+
+## Directory Structure
+
+*   `main.tf`: Contains the primary set of resource definitions for the API infrastructure (VPC, ECR, ECS, ALB, etc.).
+*   `variables.tf`: Defines input variables used to configure the infrastructure (e.g., region, environment name, CIDR blocks, container settings).
+*   `outputs.tf`: Specifies the output values from the module after provisioning (e.g., ALB DNS name, ECR repository URL).
+
+## Variables
+
+Below are some of the key variables defined in `variables.tf`. You can set these using a `.tfvars` file or by passing them as command-line arguments.
+
+*   `region`: (string) AWS region for the infrastructure (default: "us-east-1").
+*   `environment`: (string) Deployment environment (e.g., "dev", "staging", "prod") (default: "dev").
+*   `app_name`: (string) Name of the application (default: "my-api").
+*   `vpc_cidr_block`: (string) CIDR block for the VPC (default: "10.0.0.0/16").
+*   `public_subnet_a_cidr_block`: (string) CIDR block for public subnet in AZ A.
+*   `public_subnet_b_cidr_block`: (string) CIDR block for public subnet in AZ B.
+*   `private_subnet_a_cidr_block`: (string) CIDR block for private subnet in AZ A.
+*   `private_subnet_b_cidr_block`: (string) CIDR block for private subnet in AZ B.
+*   `container_port`: (number) Port the container listens on (default: 8080).
+*   `ecs_task_cpu`: (string) CPU units for the ECS task (default: "1024").
+*   `ecs_task_memory`: (string) Memory for the ECS task (in MiB) (default: "2048").
+*   `log_retention_days`: (number) Number of days to retain CloudWatch logs (default: 7).
+*   `ecs_service_desired_count`: (number) Desired number of tasks for the ECS service (default: 2).
+*   `health_check_path`: (string) Path for ALB health checks (default: "/health").
+*   `container_environment_variables`: (list(object)) Environment variables for the container.
+
+Create a `terraform.tfvars` file (e.g., `dev.tfvars`) in this directory to specify your variable values:
+```hcl
+region        = "us-east-1"
+environment   = "dev"
+app_name      = "my-cool-api"
+# ... other variables
+```
+
+## Initialization
+
+Navigate to the module directory and initialize Terraform. You will need to provide a backend configuration file or pass the configuration via the command line.
+
+Example backend configuration file (`backend-config.hcl`):
+```hcl
+bucket         = "your-terraform-state-bucket-name"
+key            = "api/dev/terraform.tfstate" # Example key, adjust for your environment
+region         = "us-east-1" # Region where the S3 bucket and DynamoDB table exist
+dynamodb_table = "your-terraform-state-lock-table"
+encrypt        = true
+```
+
+Then run:
+```bash
+cd infrastructure/aws/resources/api
+terraform init -backend-config=path/to/your/backend-config.hcl
+```
+
+## Planning
+
+Generate an execution plan to preview the changes Terraform will make:
+```bash
+terraform plan -var-file=path/to/your-dev.tfvars # Or your specific .tfvars file
+```
+
+## Applying
+
+Apply the changes to provision the infrastructure:
+```bash
+terraform apply -var-file=path/to/your-dev.tfvars
+```
+Confirm the action by typing `yes` when prompted.
+
+## Destroying
+
+To remove all resources provisioned by this module:
+```bash
+terraform destroy -var-file=path/to/your-dev.tfvars
+```
+Confirm the action by typing `yes` when prompted.
+
+## Outputs
+
+After successful application, important outputs such as the Application Load Balancer DNS name and ECR repository URL are available. You can view them using:
+```bash
+terraform output
+```
+Specific outputs can also be queried:
+```bash
+terraform output alb_dns_name
+terraform output ecr_repository_url
+```
+These outputs are defined in `outputs.tf`.

--- a/infrastructure/aws/resources/api/main.tf
+++ b/infrastructure/aws/resources/api/main.tf
@@ -1,0 +1,399 @@
+# Main configuration for the API infrastructure
+provider "aws" {
+  region = var.region
+}
+
+# VPC and Networking
+resource "aws_vpc" "main" {
+  cidr_block = var.vpc_cidr_block
+  enable_dns_support = true
+  enable_dns_hostnames = true
+  tags = {
+    Name = "${var.environment}-vpc"
+  }
+}
+
+resource "aws_internet_gateway" "gw" {
+  vpc_id = aws_vpc.main.id
+  tags = {
+    Name = "${var.environment}-igw"
+  }
+}
+
+resource "aws_subnet" "public_a" {
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = var.public_subnet_a_cidr_block
+  availability_zone = data.aws_availability_zones.available.names[0]
+  map_public_ip_on_launch = true
+  tags = {
+    Name = "${var.environment}-public-subnet-a"
+  }
+}
+
+resource "aws_subnet" "public_b" {
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = var.public_subnet_b_cidr_block
+  availability_zone = data.aws_availability_zones.available.names[1]
+  map_public_ip_on_launch = true
+  tags = {
+    Name = "${var.environment}-public-subnet-b"
+  }
+}
+
+resource "aws_subnet" "private_a" {
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = var.private_subnet_a_cidr_block
+  availability_zone = data.aws_availability_zones.available.names[0]
+  tags = {
+    Name = "${var.environment}-private-subnet-a"
+  }
+}
+
+resource "aws_subnet" "private_b" {
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = var.private_subnet_b_cidr_block
+  availability_zone = data.aws_availability_zones.available.names[1]
+  tags = {
+    Name = "${var.environment}-private-subnet-b"
+  }
+}
+
+resource "aws_eip" "nat_a" {
+  vpc = true
+  tags = {
+    Name = "${var.environment}-nat-eip-a"
+  }
+}
+
+resource "aws_eip" "nat_b" {
+  vpc = true
+  tags = {
+    Name = "${var.environment}-nat-eip-b"
+  }
+}
+
+resource "aws_nat_gateway" "nat_a" {
+  allocation_id = aws_eip.nat_a.id
+  subnet_id     = aws_subnet.public_a.id
+  tags = {
+    Name = "${var.environment}-nat-gateway-a"
+  }
+  depends_on = [aws_internet_gateway.gw]
+}
+
+resource "aws_nat_gateway" "nat_b" {
+  allocation_id = aws_eip.nat_b.id
+  subnet_id     = aws_subnet.public_b.id
+  tags = {
+    Name = "${var.environment}-nat-gateway-b"
+  }
+  depends_on = [aws_internet_gateway.gw]
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.main.id
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.gw.id
+  }
+  tags = {
+    Name = "${var.environment}-public-route-table"
+  }
+}
+
+resource "aws_route_table" "private_a" {
+  vpc_id = aws_vpc.main.id
+  route {
+    cidr_block     = "0.0.0.0/0"
+    nat_gateway_id = aws_nat_gateway.nat_a.id
+  }
+  tags = {
+    Name = "${var.environment}-private-route-table-a"
+  }
+}
+
+resource "aws_route_table" "private_b" {
+  vpc_id = aws_vpc.main.id
+  route {
+    cidr_block     = "0.0.0.0/0"
+    nat_gateway_id = aws_nat_gateway.nat_b.id
+  }
+  tags = {
+    Name = "${var.environment}-private-route-table-b"
+  }
+}
+
+resource "aws_route_table_association" "public_a" {
+  subnet_id      = aws_subnet.public_a.id
+  route_table_id = aws_route_table.public.id
+}
+
+resource "aws_route_table_association" "public_b" {
+  subnet_id      = aws_subnet.public_b.id
+  route_table_id = aws_route_table.public.id
+}
+
+resource "aws_route_table_association" "private_a" {
+  subnet_id      = aws_subnet.private_a.id
+  route_table_id = aws_route_table.private_a.id
+}
+
+resource "aws_route_table_association" "private_b" {
+  subnet_id      = aws_subnet.private_b.id
+  route_table_id = aws_route_table.private_b.id
+}
+
+resource "aws_security_group" "alb" {
+  name        = "${var.environment}-alb-sg"
+  description = "Allow HTTP/HTTPS traffic to ALB"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "${var.environment}-alb-sg"
+  }
+}
+
+resource "aws_security_group" "ecs_tasks" {
+  name        = "${var.environment}-ecs-tasks-sg"
+  description = "Allow traffic from ALB to ECS tasks"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    from_port       = var.container_port
+    to_port         = var.container_port
+    protocol        = "tcp"
+    security_groups = [aws_security_group.alb.id]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "${var.environment}-ecs-tasks-sg"
+  }
+}
+
+# ECR
+resource "aws_ecr_repository" "api" {
+  name                 = "${var.environment}-${var.app_name}"
+  image_tag_mutability = "MUTABLE"
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+
+  tags = {
+    Name = "${var.environment}-${var.app_name}-ecr"
+  }
+}
+
+# ECS
+resource "aws_ecs_cluster" "main" {
+  name = "${var.environment}-ecs-cluster"
+  tags = {
+    Name = "${var.environment}-ecs-cluster"
+  }
+}
+
+resource "aws_cloudwatch_log_group" "ecs_logs" {
+  name = "/ecs/${var.environment}-${var.app_name}"
+  retention_in_days = var.log_retention_days
+  tags = {
+    Name = "${var.environment}-${var.app_name}-logs"
+  }
+}
+
+resource "aws_ecs_task_definition" "api" {
+  family                   = "${var.environment}-${var.app_name}-task"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = var.ecs_task_cpu
+  memory                   = var.ecs_task_memory
+  execution_role_arn       = aws_iam_role.ecs_task_execution_role.arn # Will create this role later
+  task_role_arn            = aws_iam_role.ecs_task_role.arn # Will create this role later
+
+  container_definitions = jsonencode([
+    {
+      name      = "${var.environment}-${var.app_name}-container"
+      image     = "${aws_ecr_repository.api.repository_url}:latest" # Placeholder
+      cpu       = var.ecs_task_cpu
+      memory    = var.ecs_task_memory
+      essential = true
+      portMappings = [
+        {
+          containerPort = var.container_port
+          hostPort      = var.container_port
+        }
+      ]
+      environment = var.container_environment_variables
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          "awslogs-group"         = aws_cloudwatch_log_group.ecs_logs.name
+          "awslogs-region"        = var.region
+          "awslogs-stream-prefix" = "ecs"
+        }
+      }
+    }
+  ])
+
+  tags = {
+    Name = "${var.environment}-${var.app_name}-task-def"
+  }
+}
+
+# IAM Roles for ECS
+resource "aws_iam_role" "ecs_task_execution_role" {
+  name = "${var.environment}-ecs-task-execution-role"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "ecs-tasks.amazonaws.com"
+        }
+      }
+    ]
+  })
+  tags = {
+    Name = "${var.environment}-ecs-task-execution-role"
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_task_execution_role_policy" {
+  role       = aws_iam_role.ecs_task_execution_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+resource "aws_iam_role" "ecs_task_role" {
+  name = "${var.environment}-ecs-task-role"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "ecs-tasks.amazonaws.com"
+        }
+      }
+    ]
+  })
+  tags = {
+    Name = "${var.environment}-ecs-task-role"
+  }
+}
+
+# Add specific permissions to ecs_task_role if your application needs to interact with other AWS services
+
+resource "aws_ecs_service" "api" {
+  name            = "${var.environment}-${var.app_name}-service"
+  cluster         = aws_ecs_cluster.main.id
+  task_definition = aws_ecs_task_definition.api.arn
+  desired_count   = var.ecs_service_desired_count
+  launch_type     = "FARGATE"
+
+  network_configuration {
+    subnets          = [aws_subnet.private_a.id, aws_subnet.private_b.id]
+    security_groups  = [aws_security_group.ecs_tasks.id]
+    assign_public_ip = false
+  }
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.api.arn
+    container_name   = "${var.environment}-${var.app_name}-container"
+    container_port   = var.container_port
+  }
+
+  health_check_grace_period_seconds = var.ecs_service_health_check_grace_period_seconds
+
+  depends_on = [aws_lb_listener.http] # Ensure listener is created before service
+
+  tags = {
+    Name = "${var.environment}-${var.app_name}-service"
+  }
+}
+
+# ALB
+resource "aws_lb" "main" {
+  name               = "${var.environment}-alb"
+  internal           = false
+  load_balancer_type = "application"
+  security_groups    = [aws_security_group.alb.id]
+  subnets            = [aws_subnet.public_a.id, aws_subnet.public_b.id]
+
+  enable_deletion_protection = false # Set to true for production
+
+  tags = {
+    Name = "${var.environment}-alb"
+  }
+}
+
+resource "aws_lb_target_group" "api" {
+  name        = "${var.environment}-${var.app_name}-tg"
+  port        = var.container_port
+  protocol    = "HTTP"
+  vpc_id      = aws_vpc.main.id
+  target_type = "ip" # Required for Fargate
+
+  health_check {
+    enabled             = true
+    path                = var.health_check_path
+    port                = "traffic-port"
+    protocol            = "HTTP"
+    matcher             = "200-299"
+    interval            = 30
+    timeout             = 5
+    healthy_threshold   = 2
+    unhealthy_threshold = 2
+  }
+
+  tags = {
+    Name = "${var.environment}-${var.app_name}-tg"
+  }
+}
+
+resource "aws_lb_listener" "http" {
+  load_balancer_arn = aws_lb.main.arn
+  port              = 80
+  protocol          = "HTTP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.api.arn
+  }
+
+  tags = {
+    Name = "${var.environment}-http-listener"
+  }
+}
+
+# Data source for AZs
+data "aws_availability_zones" "available" {}

--- a/infrastructure/aws/resources/api/main.tf
+++ b/infrastructure/aws/resources/api/main.tf
@@ -3,6 +3,15 @@ provider "aws" {
   region = var.region
 }
 
+data "terraform_remote_state" "cognito" {
+  backend = "s3"
+  config = {
+    bucket = var.cognito_state_bucket
+    key    = var.cognito_state_key
+    region = var.region # Assuming Cognito state is in the same region as the API infrastructure
+  }
+}
+
 # VPC and Networking
 resource "aws_vpc" "main" {
   cidr_block = var.vpc_cidr_block
@@ -334,7 +343,7 @@ resource "aws_ecs_service" "api" {
 
   health_check_grace_period_seconds = var.ecs_service_health_check_grace_period_seconds
 
-  depends_on = [aws_lb_listener.http] # Ensure listener is created before service
+  depends_on = [aws_lb_listener.https] # Updated dependency to the new HTTPS listener
 
   tags = {
     Name = "${var.environment}-${var.app_name}-service"
@@ -380,18 +389,51 @@ resource "aws_lb_target_group" "api" {
   }
 }
 
-resource "aws_lb_listener" "http" {
+resource "aws_lb_listener" "https" {
   load_balancer_arn = aws_lb.main.arn
-  port              = 80
-  protocol          = "HTTP"
+  port              = 443
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-2016-08" # A common default, consider updating if specific needs arise
+  certificate_arn   = var.alb_certificate_arn
 
   default_action {
+    order = 1
+    type = "authenticate-cognito"
+    authenticate_cognito {
+      user_pool_arn       = data.terraform_remote_state.cognito.outputs.user_pool_arn
+      user_pool_client_id = data.terraform_remote_state.cognito.outputs.user_pool_client_id
+      user_pool_domain    = data.terraform_remote_state.cognito.outputs.user_pool_domain_base_url # This should be the domain prefix
+      # session_cookie_name = "AWSELBAuthSessionCookie-${var.environment}" # Optional: customize cookie name
+      on_unauthenticated_request = "authenticate" # Default is "authenticate"
+    }
+  }
+
+  default_action {
+    order            = 2
     type             = "forward"
     target_group_arn = aws_lb_target_group.api.arn
   }
 
   tags = {
-    Name = "${var.environment}-http-listener"
+    Name = "${var.environment}-https-listener"
+  }
+}
+
+resource "aws_lb_listener" "http_redirect_to_https" {
+  load_balancer_arn = aws_lb.main.arn
+  port              = 80
+  protocol          = "HTTP"
+
+  default_action {
+    type = "redirect"
+    redirect {
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301" # Permanent redirect
+    }
+  }
+  tags = {
+    Name = "${var.environment}-http-redirect-listener"
   }
 }
 

--- a/infrastructure/aws/resources/api/outputs.tf
+++ b/infrastructure/aws/resources/api/outputs.tf
@@ -1,0 +1,44 @@
+output "alb_dns_name" {
+  description = "DNS name of the Application Load Balancer"
+  value       = aws_lb.main.dns_name
+}
+
+output "ecr_repository_url" {
+  description = "URL of the ECR repository"
+  value       = aws_ecr_repository.api.repository_url
+}
+
+output "ecs_cluster_name" {
+  description = "Name of the ECS cluster"
+  value       = aws_ecs_cluster.main.name
+}
+
+output "ecs_service_name" {
+  description = "Name of the ECS service"
+  value       = aws_ecs_service.api.name
+}
+
+output "vpc_id" {
+  description = "ID of the created VPC"
+  value       = aws_vpc.main.id
+}
+
+output "public_subnet_ids" {
+  description = "IDs of the public subnets"
+  value       = [aws_subnet.public_a.id, aws_subnet.public_b.id]
+}
+
+output "private_subnet_ids" {
+  description = "IDs of the private subnets"
+  value       = [aws_subnet.private_a.id, aws_subnet.private_b.id]
+}
+
+output "alb_security_group_id" {
+  description = "ID of the ALB security group"
+  value       = aws_security_group.alb.id
+}
+
+output "ecs_tasks_security_group_id" {
+  description = "ID of the ECS tasks security group"
+  value       = aws_security_group.ecs_tasks.id
+}

--- a/infrastructure/aws/resources/api/variables.tf
+++ b/infrastructure/aws/resources/api/variables.tf
@@ -98,3 +98,18 @@ variable "container_environment_variables" {
   #   { name = "DB_PORT", value = "5432" }
   # ]
 }
+
+variable "cognito_state_bucket" {
+  description = "Name of the S3 bucket where the Cognito module's Terraform state is stored."
+  type        = string
+}
+
+variable "cognito_state_key" {
+  description = "Path to the Cognito module's Terraform state file in the S3 bucket."
+  type        = string
+}
+
+variable "alb_certificate_arn" {
+  description = "ARN of the ACM certificate for the ALB HTTPS listener."
+  type        = string
+}

--- a/infrastructure/aws/resources/api/variables.tf
+++ b/infrastructure/aws/resources/api/variables.tf
@@ -1,0 +1,100 @@
+variable "region" {
+  description = "AWS region for the infrastructure"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "environment" {
+  description = "Deployment environment (e.g., dev, staging, prod)"
+  type        = string
+  default     = "dev"
+}
+
+variable "app_name" {
+  description = "Name of the application"
+  type        = string
+  default     = "my-api"
+}
+
+variable "vpc_cidr_block" {
+  description = "CIDR block for the VPC"
+  type        = string
+  default     = "10.0.0.0/16"
+}
+
+variable "public_subnet_a_cidr_block" {
+  description = "CIDR block for public subnet in AZ A"
+  type        = string
+  default     = "10.0.1.0/24"
+}
+
+variable "public_subnet_b_cidr_block" {
+  description = "CIDR block for public subnet in AZ B"
+  type        = string
+  default     = "10.0.2.0/24"
+}
+
+variable "private_subnet_a_cidr_block" {
+  description = "CIDR block for private subnet in AZ A"
+  type        = string
+  default     = "10.0.3.0/24"
+}
+
+variable "private_subnet_b_cidr_block" {
+  description = "CIDR block for private subnet in AZ B"
+  type        = string
+  default     = "10.0.4.0/24"
+}
+
+variable "container_port" {
+  description = "Port the container listens on"
+  type        = number
+  default     = 8080
+}
+
+variable "ecs_task_cpu" {
+  description = "CPU units for the ECS task"
+  type        = string
+  default     = "1024" # 1 vCPU
+}
+
+variable "ecs_task_memory" {
+  description = "Memory for the ECS task (in MiB)"
+  type        = string
+  default     = "2048" # 2GB
+}
+
+variable "log_retention_days" {
+  description = "Number of days to retain CloudWatch logs"
+  type        = number
+  default     = 7
+}
+
+variable "ecs_service_desired_count" {
+  description = "Desired number of tasks for the ECS service"
+  type        = number
+  default     = 2
+}
+
+variable "ecs_service_health_check_grace_period_seconds" {
+  description = "Grace period for ECS service health checks"
+  type        = number
+  default     = 60
+}
+
+variable "health_check_path" {
+  description = "Path for ALB health checks"
+  type        = string
+  default     = "/health"
+}
+
+variable "container_environment_variables" {
+  description = "Environment variables for the container (list of objects with name and value)"
+  type        = list(object({ name = string, value = string }))
+  default     = []
+  # Example:
+  # [
+  #   { name = "DB_HOST", value = "mydb.example.com" },
+  #   { name = "DB_PORT", value = "5432" }
+  # ]
+}


### PR DESCRIPTION
This commit introduces the necessary AWS infrastructure to deploy the backend API. It includes:

1.  **Terraform Infrastructure (`infrastructure/aws/resources/api`):**
    *   New Terraform module to provision VPC, subnets, NAT gateways, internet gateway, security groups.
    *   ECR repository for storing the API Docker image.
    *   ECS cluster, task definition, and service for running the API.
    *   Application Load Balancer to distribute traffic to the ECS service.
    *   CloudWatch logging configuration for the ECS tasks.
    *   README file explaining how to provision and manage this infrastructure.

2.  **Dockerfile Optimization (`backend/api/Dockerfile`):**
    *   Improved layer caching for faster builds.
    *   Reduced image size by removing unnecessary packages (`shadow-utils`).
    *   Refined non-root user creation.

3.  **GitHub Actions CI/CD (`.github/workflows/docker-image-push.yml`):**
    *   Updated workflow to trigger on push to the `main` branch.
    *   Authenticates with AWS, logs into ECR.
    *   Builds the API Docker image, tags it, and pushes it to ECR.
    *   Deploys to ECS by downloading the current task definition, updating the image URI, registering a new task definition revision, and updating the ECS service to use the new revision.

4.  **Local Development Setup (`docker-compose.yaml`):**
    *   Corrected the `app` service configuration by removing build `args` that were incorrectly baking database credentials into the image. The application will now use runtime environment variables as intended.

5.  **Documentation:**
    *   Added `infrastructure/aws/resources/api/README.md`.
    *   Created a new main `README.md` at the project root, providing an overview of the project, AWS infrastructure, deployment process, local development, and other relevant information.